### PR TITLE
fixed latest download deletion option

### DIFF
--- a/includes/FileManager.ahk
+++ b/includes/FileManager.ahk
@@ -44,7 +44,7 @@ saveVideoURLDirectlyToFile()
     A_Clipboard := ""
     MouseClick("Right")
     ; Do not decrease values ! May lead to unstable performance.
-    Sleep(100)
+    Sleep(250)
     ; Probably only works with German Firefox version.
     ; Will be language specific in the future.
     Send("k")

--- a/includes/HotKeys & Methods.ahk
+++ b/includes/HotKeys & Methods.ahk
@@ -223,7 +223,7 @@ startDownload(pCommandString, pBooleanSilent := hideDownloadCommandPromptCheckbo
         displayAndLogConsoleCommand(stringToExecute, false)
         monitorDownloadProgress()
     }
-    If (downloadOptionsGUI_SubmitObject.DownloadVideoSubtitlesCheckbox = 1)
+    If (downloadOptionsGUI_SubmitObject.downloadVideoCommentsCheckbox = 1)
     {
         ; This is the work around for the missing --paths option for comments in yt-dlp (WIP).
         If (downloadOptionsGUI_SubmitObject.UseDefaultDownloadLocationCheckbox = 1)
@@ -760,10 +760,9 @@ deleteFilePrompt(pFileName)
                     }
                 Case "latest download":
                     {
-                        MsgBox(lastDownloadPath)
                         If (DirExist(lastDownloadPath))
                         {
-                            FileMove(lastDownloadPath, baseFilesLocation . "\deleted\" . downloadTime, true)
+                            DirMove(lastDownloadPath, baseFilesLocation . "\deleted\" . downloadTime, true)
                         }
                         Else
                         {


### PR DESCRIPTION
The latest download can now be deleted correctly.
The delay for the thumbnail URL pickup hotkey has been increased to make it work more often (still a better solution needed). Minor bugfixes.